### PR TITLE
docs: add weekly progress reports (Winter + Spring terms)

### DIFF
--- a/docs/weekly_progress_reports.md
+++ b/docs/weekly_progress_reports.md
@@ -1,0 +1,1189 @@
+# Universal Plastic Shredder V2.0 — Weekly Progress Reports
+
+**Course:** ECE 412/413 (Spring 2026) · **Sponsor:** MME / Ichor Systems
+**Team:** Bao Nguyen, Fearghus Tyler, Yaqoub Rabiah, Fox Kang
+
+> **Note on drafted content:** Lines tagged `_(draft — verify)_` were filled in by
+> AI from project context to complete blank sections (notably Fox Kang's entries and
+> Weeks 8–10). **Verify or edit these before submitting** — they are plausible
+> placeholders, not recorded fact. Once confirmed, you can delete the tags.
+>
+> **Note on hours:** Where hours were missing they were estimated at roughly
+> 4 hours/person/week (more in the build-heavy final weeks). These are rough
+> estimates — adjust to your actual time logs.
+
+---
+
+# Winter Term (Dec 2025 – Mar 2026)
+
+## Report date: 2025-12-17
+
+### Last week (hours)
+
+**Team Review**
+- The electrical and mechanical teams held the first coordination meeting for the shredder project.
+- We discussed the overall system design, safety systems, and motor-control ideas.
+- The team also set up communication tools and began researching components.
+
+**Bao Nguyen**
+- Created Discord server for team communication. (1)
+- Attended coordination meeting with ME team. (1)
+- Began researching HMI display options. (3)
+
+**Fearghus Tyler**
+- Discussed motor requirements with mechanical team. (2)
+- Attended coordination meeting with ME team. (1)
+- Researched possible motor options. (2)
+
+**Yaqoub Rabiah**
+- Started researching VFD motor-control systems. (3)
+- Attended coordination meeting with ME team. (1)
+
+**Fox Kang**
+- Started researching safety sensors and safety concepts. (3)
+- Attended coordination meeting with ME team. (1)
+
+### Next week
+
+**Team Plan**
+- Continue researching components and begin building comparison tables for motors, sensors, and control systems.
+
+**Bao Nguyen**
+- Research HMI options and telemetry display ideas. (3)
+
+**Fearghus Tyler**
+- Begin creating preliminary electrical BOM. (3)
+
+**Yaqoub Rabiah**
+- Research VFD telemetry and monitoring features. (3)
+
+**Fox Kang**
+- Continue researching safety detection methods. (3)
+
+### Blocked
+
+**Bao Nguyen**
+- Waiting for motor requirements from mechanical team.
+
+**Fearghus Tyler**
+- Waiting for gearbox specifications.
+
+**Yaqoub Rabiah**
+- Waiting for VFD model.
+
+**Fox Kang**
+- None.
+
+---
+
+## Report date: 2026-01-03
+
+### Last week (hours)
+
+**Team Review**
+- The team continued researching electrical components for the shredder system.
+- Motors, HMIs, and safety sensors were compared.
+- Early ideas for the electrical control system were discussed.
+
+**Bao Nguyen**
+- Researched HMI display options. (3)
+- Reviewed possible telemetry information to display. (2)
+
+**Fearghus Tyler**
+- Began building list of electrical components for initial test setup. (3)
+
+**Yaqoub Rabiah**
+- Compared VFD options and specifications. (3)
+
+**Fox Kang**
+- Continued safety-sensor research. (3)
+
+### Next week
+
+**Team Plan**
+- Narrow down hardware options and begin planning electrical architecture.
+
+**Bao Nguyen**
+- Work on system block diagram. (3)
+
+**Fearghus Tyler**
+- Expand electrical BOM. (3)
+
+**Yaqoub Rabiah**
+- Research PLC integration with VFD. (3)
+
+**Fox Kang**
+- Continue researching safety interlocks. (3)
+
+### Blocked
+
+**Bao Nguyen**
+- Waiting for enclosure dimensions.
+
+**Fearghus Tyler**
+- Waiting for torque specifications.
+
+**Yaqoub Rabiah**
+- Waiting for PLC to arrive.
+
+**Fox Kang**
+- Stuck on figuring out the type of technology for the safety sensor.
+
+---
+
+## Report date: 2026-01-09
+
+### Last week (hours)
+
+**Team Review**
+- The team met with the faculty advisor and industry sponsor to review project goals.
+- Budget, motor power, and safety requirements were discussed.
+
+**Bao Nguyen**
+- Attended sponsor meeting. (1)
+- Researched HMI communication options. (3)
+
+**Fearghus Tyler**
+- Continued working on electrical BOM. (3)
+- Attended sponsor meeting. (1)
+
+**Yaqoub Rabiah**
+- Researched VFD control and monitoring options. (4)
+
+**Fox Kang**
+- Continued researching safety sensors. (3)
+
+### Next week
+
+**Team Plan**
+- Start developing electrical system architecture.
+
+**Bao Nguyen**
+- Work on system layout diagram. (3)
+
+**Fearghus Tyler**
+- Continue updating BOM. (3)
+
+**Yaqoub Rabiah**
+- Compare VFD options. (3)
+
+**Fox Kang**
+- Research safety-sensor placement. (3)
+
+### Blocked
+
+**Bao Nguyen**
+- Waiting for motor specs.
+
+**Fearghus Tyler**
+- Waiting for gearbox decision.
+
+**Yaqoub Rabiah**
+- Waiting on PLC.
+
+**Fox Kang**
+- Waiting on HMI.
+
+---
+
+## Report date: 2026-01-16
+
+### Last week (hours)
+
+**Team Review**
+- The electrical team reviewed motor-control strategies and safety systems.
+- Design ideas for the electrical system were discussed.
+
+**Bao Nguyen**
+- Tested small motor and VFD setup. (4)
+
+**Fearghus Tyler**
+- Worked with mechanical team on gearbox ideas. (3)
+
+**Yaqoub Rabiah**
+- Reviewed VFD specifications. (3)
+
+**Fox Kang**
+- Created accident-scenario safety flow chart. (3)
+
+### Next week
+
+**Team Plan**
+- Continue developing electrical control-system design.
+
+**Bao Nguyen**
+- Work on electrical control-circuit layout. (3)
+
+**Fearghus Tyler**
+- Update electrical BOM. (3)
+
+**Yaqoub Rabiah**
+- Continue VFD research. (3)
+
+**Fox Kang**
+- Continue safety-system research. (3)
+
+### Blocked
+
+**Bao Nguyen**
+- Waiting for gearbox decision.
+
+**Fearghus Tyler**
+- Waiting for enclosure size.
+
+**Yaqoub Rabiah**
+- Waiting on equipment to program PLC.
+
+**Fox Kang**
+- Choosing the correct parts for the safety sensors.
+
+---
+
+## Report date: 2026-01-23
+
+### Last week (hours)
+
+**Team Review**
+- The team began developing the electrical design and continued coordination with the mechanical team.
+
+**Bao Nguyen**
+- Worked on electrical system design. (3)
+
+**Fearghus Tyler**
+- Updated electrical BOM for initial purchases. (3)
+- Set up CAD schematics according to these specs.
+
+**Yaqoub Rabiah**
+- Began PLC control-logic planning. (3)
+
+**Fox Kang**
+- Continued safety-system research. (3)
+
+### Next week
+
+**Team Plan**
+- Start building prototype circuits and system diagrams.
+
+**Bao Nguyen**
+- Design electrical circuit diagram. (3)
+
+**Fearghus Tyler**
+- Continue component sourcing. (3)
+
+**Yaqoub Rabiah**
+- Develop PLC logic structure. (3)
+
+**Fox Kang**
+- Develop safety-system concept. (3)
+
+### Blocked
+
+**Bao Nguyen**
+- Waiting for motor specs.
+
+**Fearghus Tyler**
+- None.
+
+**Yaqoub Rabiah**
+- None.
+
+**Fox Kang**
+- None.
+
+---
+
+## Report date: 2026-02-02
+
+### Last week (hours)
+
+**Team Review**
+- The team worked on prototype development and safety-system concepts.
+
+**Bao Nguyen**
+- Began building electrical test rig. (4)
+
+**Fearghus Tyler**
+- Worked on electrical CAD schematic. (3)
+
+**Yaqoub Rabiah**
+- Developed PLC control logic. (3)
+
+**Fox Kang**
+- Requested capacitive-sensor samples. (2)
+
+### Next week
+
+**Team Plan**
+- Continue prototype testing and system development.
+
+**Bao Nguyen**
+- Continue test-rig development. (3)
+
+**Fearghus Tyler**
+- Improve schematic design. (3)
+
+**Yaqoub Rabiah**
+- Continue PLC programming. (3)
+
+**Fox Kang**
+- Develop safety-sensor circuit. (3)
+
+### Blocked
+
+**Bao Nguyen**
+- Waiting for some parts to arrive.
+
+**Fearghus Tyler**
+- None.
+
+**Yaqoub Rabiah**
+- None.
+
+**Fox Kang**
+- Waiting for sensor samples.
+
+---
+
+## Report date: 2026-02-06
+
+### Last week (hours)
+
+**Team Review**
+- Continued electrical design work and coordination with the mechanical team.
+
+**Bao Nguyen**
+- Worked on wiring prototype components. (3)
+
+**Fearghus Tyler**
+- Updated schematic diagrams. (3)
+
+**Yaqoub Rabiah**
+- Continued PLC logic work. (3)
+
+**Fox Kang**
+- Worked on safety-system design. (3)
+
+### Next week
+
+**Team Plan**
+- Continue system testing and design improvements.
+
+**Bao Nguyen**
+- Continue prototype wiring. (3)
+
+**Fearghus Tyler**
+- Review schematic design. (3)
+
+**Yaqoub Rabiah**
+- Continue PLC programming. (3)
+
+**Fox Kang**
+- Continue safety-system research. (3)
+
+### Blocked
+- None.
+
+---
+
+## Report date: 2026-02-13
+
+### Last week (hours)
+
+**Team Review**
+- The team met with the advisor to discuss project coordination and integration with the mechanical design.
+
+**Bao Nguyen**
+- Attended advisor meeting. (1)
+- Worked on electrical layout planning. (2)
+
+**Fearghus Tyler**
+- Continued schematic design. (3)
+- Attended advisor meeting. (1)
+
+**Yaqoub Rabiah**
+- Worked on PLC logic improvements. (3)
+- Attended advisor meeting. (1)
+
+**Fox Kang**
+- Updated safety documentation. (3)
+- Attended advisor meeting. (1)
+
+### Next week
+
+**Team Plan**
+- Continue electrical design and documentation work.
+
+**Bao Nguyen**
+- _Continue electrical layout planning. (draft — verify)_
+
+**Fearghus Tyler**
+- _Continue schematic design once updated CAD arrives from ME team. (draft — verify)_
+
+**Yaqoub Rabiah**
+- _Continue PLC logic improvements. (draft — verify)_
+
+**Fox Kang**
+- _Continue safety documentation and sensor research. (draft — verify)_
+
+### Blocked
+
+**Bao Nguyen**
+- _None this week. (draft — verify)_
+
+**Fearghus Tyler**
+- Waiting for updated CAD from ME team.
+
+**Yaqoub Rabiah**
+- _None this week. (draft — verify)_
+
+**Fox Kang**
+- _None this week. (draft — verify)_
+
+---
+
+## Report date: 2026-02-27
+
+### Last week (hours)
+
+**Team Review**
+- The team focused on preparing documentation and presentation materials.
+
+**Bao Nguyen**
+- Updated electrical design diagrams. (3)
+
+**Fearghus Tyler**
+- Reviewed component selections. (3)
+
+**Yaqoub Rabiah**
+- Reviewed PLC logic. (3)
+
+**Fox Kang**
+- Updated safety documentation. (3)
+
+### Next week
+
+**Team Plan**
+- Continue preparing final presentation materials.
+
+**Bao Nguyen**
+- _Finalize electrical design diagrams for the presentation. (draft — verify)_
+
+**Fearghus Tyler**
+- _Finalize component-selection list. (draft — verify)_
+
+**Yaqoub Rabiah**
+- _Finalize PLC logic write-up. (draft — verify)_
+
+**Fox Kang**
+- _Finalize safety documentation. (draft — verify)_
+
+### Blocked
+- None.
+
+---
+
+## Report date: 2026-03-06
+
+### Last week (hours)
+
+**Team Review**
+- The team finally got the parts they requested.
+
+**Bao Nguyen**
+- Fit parts to our prototype and wire it. (3)
+
+**Fearghus Tyler**
+- Fit parts to our prototype and wire it. (3)
+
+**Yaqoub Rabiah**
+- Started figuring out C-more to program the HMI. (3)
+
+**Fox Kang**
+- Cargo delay; exploring backup plans. (2)
+
+### Next week
+
+**Team Plan**
+- Try figuring out the VFD phases to have a working motor.
+
+**Bao Nguyen**
+- _Continue wiring the prototype and work on the VFD/motor combo. (draft — verify)_
+
+**Fearghus Tyler**
+- _Continue fitting and wiring prototype parts. (draft — verify)_
+
+**Yaqoub Rabiah**
+- _Continue learning C-more and building the HMI. (draft — verify)_
+
+**Fox Kang**
+- _Pursue capacitive-touch backup plan while waiting on the chip. (draft — verify)_
+
+### Blocked
+
+**Bao Nguyen**
+- Waiting on E-stop switch.
+
+**Fearghus Tyler**
+- _None this week. (draft — verify)_
+
+**Yaqoub Rabiah**
+- _None this week. (draft — verify)_
+
+**Fox Kang**
+- _Cargo delay on capacitive-touch parts. (draft — verify)_
+
+---
+
+## Report date: 2026-03-13
+
+### Last week (hours)
+
+**Team Review**
+- Started wiring up our prototype and getting the VFD to work.
+
+**Bao Nguyen**
+- Work on the VFD and motor combo. (3)
+
+**Fearghus Tyler**
+- Work on the VFD and motor combo. (3)
+
+**Yaqoub Rabiah**
+- Continued developing the HMI GUI. (3)
+
+**Fox Kang**
+- Get the capacitive-touch chip and prepare for the demo. (3)
+
+### Next week
+
+**Team Plan**
+- Finalize the documentation before spring break.
+
+**Bao Nguyen**
+- _Continue VFD/motor work and document the setup. (draft — verify)_
+
+**Fearghus Tyler**
+- _Continue VFD/motor wiring and update schematics. (draft — verify)_
+
+**Yaqoub Rabiah**
+- _Continue developing the HMI GUI. (draft — verify)_
+
+**Fox Kang**
+- _Prepare the capacitive-touch chip for the demo. (draft — verify)_
+
+### Blocked
+- None.
+
+---
+
+## Report date: 2026-03-16
+
+### Last week (hours)
+
+**Team Review**
+- The team finalized project documentation and presentation materials.
+
+**Bao Nguyen**
+- Updated diagrams and documentation. (3)
+
+**Fearghus Tyler**
+- Reviewed schematic documentation. (2)
+
+**Yaqoub Rabiah**
+- Reviewed PLC control-logic documentation. (2)
+
+**Fox Kang**
+- Reviewed safety documentation. (2)
+
+### Next week
+
+**Team Plan**
+- Use connectors to make it easy for the ME team to install onto the shredder.
+- With the extra time we have, we can implement other kinds of safety sensors.
+
+**Bao Nguyen**
+- _Add connectors so the ME team can easily install the electrical system. (draft — verify)_
+
+**Fearghus Tyler**
+- _Update schematics to reflect the connectorized interface. (draft — verify)_
+
+**Yaqoub Rabiah**
+- _Continue PLC/HMI documentation. (draft — verify)_
+
+**Fox Kang**
+- _Explore additional safety sensors with the extra time. (draft — verify)_
+
+### Blocked
+- None.
+
+---
+
+> _Spring break between 2026-03-16 and 2026-04-03._
+
+---
+
+# Spring Term (April – June 2026)
+
+## Week 1 — Report date: 2026-04-03
+
+### Last week (hours)
+
+**Team Review**
+- Refocused on getting back on track after spring break (3 hours)
+
+**Bao Nguyen (4)**
+- Redoing the points list because the sponsor wanted it in a different style. (4)
+- Install and wire E-Stop button to contactor. (1)
+
+**Fearghus Tyler**
+- Continued to work on the wiring schematics/model to match the points list. (2)
+- Continued support in wiring and design aspects of the protoboard. (1)
+- Revised 3D model to accommodate sponsor feedback. (1)
+
+**Yaqoub Rabiah**
+- Figured out a rework of the HMI GUI. Concept wasn't liked by the sponsor. Made it sleeker in concept. (3 hours)
+
+**Fox Kang**
+- Working on capacitive-touch concept.
+- _Researched capacitive sensing approaches for the operator-presence safety feature; scoped a touch-to-stop interlock that drops the run command via PLC input X7. (3 hours) (draft — verify)_
+
+### Next week
+
+**Team Plan**
+- Start integrating the PLC, VFD, and HMI together for our demo.
+- Start materializing the final report.
+- Start prototyping the capacitive-touch feature.
+
+**Bao Nguyen**
+- Start integrating PLC with the circuit to turn on and control the VFD.
+
+**Fearghus Tyler**
+- Set up the VFD to work using the analog and digital inputs instead of the default factory settings (0–10 V).
+- Coordinated with the industry sponsor controls team to confirm preferred termination conventions.
+- Cross-reference motor data against VFD.
+
+**Yaqoub Rabiah**
+- Start integrating PLC with the circuit to turn on and control the VFD.
+
+**Fox Kang**
+- Editing code comments and preparing connecting the module to the PLC.
+
+### Blocked
+
+**Bao Nguyen**
+- PLC 24 V module not suitable for contactor and LED control — need to find a relay module instead.
+
+**Fearghus Tyler**
+- Need to know where the connections will be before finishing the schematics.
+
+**Yaqoub Rabiah**
+- _None this week. (draft — verify)_
+
+**Fox Kang**
+- _None this week. (draft — verify)_
+
+---
+
+## Week 2 — Report date: 2026-04-10
+
+### Last week (hours)
+
+**Team Review**
+- Made progress towards the capacitive-touch feature; works on a small scale. (5 hours)
+- Integrated the PLC to the circuit. Contactor turns on with deadman switches, as well as the VFD. (8 hours)
+
+**Bao Nguyen**
+- Rewired PLC and contactor to ensure integration stays smooth. (4 hours)
+- Swapped and identified problematic modules such as the current-controlled analog module. (4 hours)
+
+**Fearghus Tyler**
+- Tested the protoboard with the analog and digital inputs. Ready to test with HMI. (2)
+- Created some 2D wiring diagrams of different versions for field vs. internal cabinet wiring. (2)
+
+**Yaqoub Rabiah**
+- Reprogrammed the logic code for the PLC, ensuring the bits corresponded to the physical circuit. (2 hours)
+- Debugged the deadman and start/stop functions to specs while integrating the PLC. (4 hours)
+- Laid the foundation for the weekly progress reports. (3 hours)
+
+**Fox Kang**
+- _Prototyped the capacitive-touch sensor on a breadboard; confirmed it triggers reliably on a small test surface. (5 hours) (draft — verify)_
+- _Began wiring the module output toward the PLC X7 input for the touch-to-stop interlock. (draft — verify)_
+
+### Next week
+
+**Team Plan**
+- Continue integrating the PLC, VFD, and HMI together for our demo.
+- Start materializing the final report.
+
+**Bao Nguyen**
+- Continue integrating PLC with the circuit to turn on the VFD.
+
+**Fearghus Tyler**
+- Work with the industry sponsor to schedule a controls-team review of our materials.
+- Investigated VFD behavior under current control vs. voltage control. Documented the odd current readings off the module (possibly broken?).
+
+**Yaqoub Rabiah**
+- Continue reworking the logic and HMI design for further integration.
+
+**Fox Kang**
+- _Tune sensitivity and debounce on the cap-touch prototype; reduce false triggers before PLC integration. (draft — verify)_
+
+### Blocked
+
+**Bao Nguyen**
+- _None this week. (draft — verify)_
+
+**Fearghus Tyler**
+- Need to know their final motor specs.
+
+**Yaqoub Rabiah**
+- RPM control is acting weird.
+
+**Fox Kang**
+- _None this week. (draft — verify)_
+
+---
+
+## Week 3 — Report date: 2026-04-17
+
+### Last week (hours)
+
+**Team Review**
+- Integrating PLC, HMI, VFD and motor. (8 hours)
+
+**Bao Nguyen**
+- Investigated why the 12–24 VDC output module was not behaving like a proper on/off switch. Discovered that although it functions as a switch, the lowest output voltage is still too high to reliably control devices that require a clear digital signal, such as a contactor. (4)
+- Located a relay module in the Power Lab and wired it into the system to properly interface the PLC output with external loads. Tested the relay module using indicator lights on the module to confirm correct switching behavior. (2)
+- Began studying the analog modules to understand their wiring and signal operation within the PLC system. Currently working on determining the correct configuration and integration method. (6)
+
+**Fearghus Tyler**
+- Proposed switching from current control to voltage control (0–10 V) to the team and sponsor. (1)
+- Updated 2D schematic to reflect planned analog module swap. (2)
+- Revised 3D control-panel model to show new voltage-module placement and wire routing.
+
+**Yaqoub Rabiah**
+- Integrated a scale for RPM control from the HMI to the PLC. (2 hours)
+- Added forward and reverse capabilities into PLC logic and integrated it into the HMI. (5 hours)
+- Reworked the numerical displays on the main page of the HMI. (2 hours)
+- Debugged the connection between the PLC and HMI. The protocols weren't matching. (2 hours)
+- Found a problem with the current-control module and tried to debug. (4 hours)
+
+**Fox Kang**
+- _Continued bench prototyping of the cap-touch module; worked on suppressing false triggers from electrical noise near the panel. (4 hours) (draft — verify)_
+
+### Next week
+
+**Team Plan**
+- Figure out the problem of the low amperage variance in the current-control module.
+
+**Bao Nguyen**
+- _Continue analog-module study; determine correct wiring/scaling for PLC integration. (draft — verify)_
+
+**Fearghus Tyler**
+- Reprogrammed VFD parameters from current-control mode to voltage-control mode (0–10 V) following analog module swap. (3)
+- Bench-tested VFD response to 0–10 V signal from PLC; verified linear RPM control within expected range. (2)
+- Updated schematics and 2D wiring diagrams to reflect final analog module configuration and E-stop logic paths. (3)
+- Generated updated 3D enclosure model for ICHOR's final design package. (2)
+
+**Yaqoub Rabiah**
+- Fix logic for the cc module.
+
+**Fox Kang**
+- _Prepare cap-touch module output for wiring to PLC X7 and test the touch-trip stop. (draft — verify)_
+
+### Blocked
+
+**Bao Nguyen**
+- Currently working on understanding how the analog module is wired and configured within the PLC system. Still determining the correct wiring for the analog inputs/outputs and how the signals should be scaled and interpreted by the PLC. Further testing and documentation review are needed before integration with the rest of the system.
+
+**Fearghus Tyler**
+- Troubleshooting current-controlled VFD motor control; running into issues with ranges.
+
+**Yaqoub Rabiah**
+- Can't seem to program the current-control module such that the range is more than 0–0.3 mA.
+
+**Fox Kang**
+- _None this week. (draft — verify)_
+
+---
+
+## Week 4 — Report date: 2026-04-24
+
+### Last week (hours)
+
+**Team Review**
+- Swapped current control with voltage control module, thus ending current-control confusion.
+
+**Bao Nguyen**
+- Swapped current-control module to a voltage-control module and read documentation on configuring the module. Identified the program bits where it stores RPM data from the scaling command in Do-more Designer with Yaqoub. (4)
+- Working with Fearghus on reprogramming the VFD. (2)
+
+**Fearghus Tyler**
+- Tested and reprogrammed the VFD to match the change from current-controlled to voltage-controlled module. (4)
+- Prepare any remaining VFD/PLC/HMI integration specs before demo.
+
+**Yaqoub Rabiah**
+- Reprogrammed the PLC to accommodate the new module. (2 hours)
+- Added LED logic for forward and reverse and swapped bits for easier wiring. (1 hour)
+- Added E-STOP logic as well as a warning-light output for safety. (1 hour)
+
+**Fox Kang**
+- _Refined cap-touch firmware/code comments and prepped the module for hand-off to PLC integration. (3 hours) (draft — verify)_
+
+### Next week
+
+**Team Plan**
+- Do the presentation.
+
+**Bao Nguyen**
+- _Support presentation prep; begin sourcing remaining parts (relay, enclosure). (draft — verify)_
+
+**Fearghus Tyler**
+- Figure out any last-minute parts we could integrate.
+- Investigate braking resistor.
+
+**Yaqoub Rabiah**
+- Get ready for presentation.
+
+**Fox Kang**
+- _Prepare cap-touch demo material for the presentation. (draft — verify)_
+
+### Blocked
+
+**Bao Nguyen**
+- _None this week. (draft — verify)_
+
+**Fearghus Tyler**
+- None.
+
+**Yaqoub Rabiah**
+- None.
+
+**Fox Kang**
+- _None this week. (draft — verify)_
+
+---
+
+## Week 5 — Report date: 2026-05-01
+
+### Last week (hours)
+
+**Team Review**
+- Did presentation. (2 hours)
+- Prototyped capacitive touch. (2 hours)
+
+**Bao Nguyen**
+- Worked with Fox to tune and build a prototype of the CTSI capacitive-touch safety interface. (2)
+- Identified new parts that are needed such as braking resistor and enclosure.
+
+**Fearghus Tyler**
+- Calculated braking-resistor size. (1)
+- Got started on a user manual. (2)
+- Receiving final supplies from industry sponsors (enclosure, braking resistor, relay for integrating capacitive touch). (1)
+
+**Yaqoub Rabiah**
+- Worked on presentation slides. (1 hour)
+
+**Fox Kang**
+- _Worked with Bao to tune and build the CTSI capacitive-touch prototype; confirmed the touch-to-stop concept on the bench. (2 hours) (draft — verify)_
+
+### Next week
+
+**Team Plan**
+- Work on enclosure.
+
+**Bao Nguyen**
+- _Continue identifying/ordering remaining parts and support enclosure build. (draft — verify)_
+
+**Fearghus Tyler**
+- Build and test.
+
+**Yaqoub Rabiah**
+- Try integrating overcurrent signal.
+
+**Fox Kang**
+- _Continue developing the CTSI module toward panel integration. (draft — verify)_
+
+### Blocked
+
+**Bao Nguyen**
+- _None this week. (draft — verify)_
+
+**Fearghus Tyler**
+- We can't test a lot of the functionality we had aimed for due to no shredder prototype built yet.
+
+**Yaqoub Rabiah**
+- Waiting for parts.
+
+**Fox Kang**
+- _Waiting on the relay for integrating capacitive touch. (draft — verify)_
+
+---
+
+## Week 6 — Report date: 2026-05-08
+
+### Last week (hours)
+
+**Team Review**
+- Not much (midterm exam week).
+
+**Bao Nguyen**
+- Nothing — exam week.
+
+**Fearghus Tyler**
+- Midterm exams took priority; we mostly worked on documentation.
+- Minor schematic changes based on the PLC logic for switching.
+
+**Yaqoub Rabiah**
+- Not much also (exam week).
+
+**Fox Kang**
+- _Exam week — minimal progress; reviewed cap-touch integration plan. (draft — verify)_
+
+### Next week
+
+**Team Plan**
+- Work on enclosure setup.
+
+**Bao Nguyen**
+- _Resume parts sourcing and enclosure prep after exams. (draft — verify)_
+
+**Fearghus Tyler**
+- Get the last parts from Ichor Systems.
+
+**Yaqoub Rabiah**
+- Try integrating overcurrent signal.
+
+**Fox Kang**
+- _Resume cap-touch integration once the relay arrives. (draft — verify)_
+
+### Blocked
+
+**Bao Nguyen**
+- _Exam week. (draft — verify)_
+
+**Fearghus Tyler**
+- Waiting for parts.
+
+**Yaqoub Rabiah**
+- Waiting for parts.
+
+**Fox Kang**
+- _Waiting for parts. (draft — verify)_
+
+---
+
+## Week 7 — Report date: 2026-05-15
+
+### Last week (hours)
+
+**Team Review**
+- Set up the control panel to go inside the enclosure. (5 hours)
+- Worked on the overcurrent-signal integration. (10 hours)
+
+**Bao Nguyen**
+- _Helped lay out and wire the control panel into the enclosure; supported overcurrent-signal wiring. (12 hours) (draft — verify)_
+
+**Fearghus Tyler**
+- We got our enclosure, so I worked on the CAD designs for the panel design and additional panel DWGs. (4)
+- Did a lot of troubleshooting and design changes for a clean enclosure. (3)
+- Helped Fox periodically with the cap-touch module. (1)
+
+**Yaqoub Rabiah**
+- Wrote logic that takes the overcurrent signal and starts an algorithm that clears the shredder. (10 hours)
+- Helped design the enclosure layout. (1 hour)
+- Drilled holes on the panel that holds the major components (VFD, contactor, circuit breakers, etc.). (1 hour)
+- Helped wire the components in the enclosure. (2 hours)
+
+**Fox Kang**
+- _Worked on the cap-touch module with Fearghus's help; progressed toward wiring it into the panel/X7. (4 hours) (draft — verify)_
+
+### Next week
+
+**Team Plan**
+- Finish up the enclosure setup and make sure it works — plug 'n' play.
+
+**Bao Nguyen**
+- _Continue enclosure wiring and verify panel integration. (draft — verify)_
+
+**Fearghus Tyler**
+- Work on the final documentation / user manual / designs.
+
+**Yaqoub Rabiah**
+- Finish enclosure setup.
+- Make sure logic works.
+- Set up cap touch.
+
+**Fox Kang**
+- _Integrate and test the cap-touch module on X7 in the enclosure. (draft — verify)_
+
+### Blocked
+
+**Bao Nguyen**
+- _None this week. (draft — verify)_
+
+**Fearghus Tyler**
+- Still no prototype shredder to test on.
+
+**Yaqoub Rabiah**
+- _None this week. (draft — verify)_
+
+**Fox Kang**
+- _None this week. (draft — verify)_
+
+---
+
+## Week 8 — Report date: 2026-05-22
+
+### Last week (hours)
+
+**Team Review**
+- _Continued enclosure wiring and panel troubleshooting; coordinated parts hand-off with the mechanical team. (draft — verify)_
+- _Roughly 20 team-hours this week. (draft — verify)_
+
+**Bao Nguyen**
+- _Continued wiring/troubleshooting the control panel and verifying PLC I/O against the points list. (14 hours) (draft — verify)_
+
+**Fearghus Tyler**
+- Worked on wiring the panel / troubleshooting. (5)
+- Helped the mech team get their parts (at long last). (3)
+
+**Yaqoub Rabiah**
+- _Continued debugging PLC logic against the wired panel; verified overcurrent-clear routine behavior. (6 hours) (draft — verify)_
+
+**Fox Kang**
+- _Continued integrating and testing the cap-touch module wiring into the panel. (4 hours) (draft — verify)_
+
+### Next week
+
+**Team Plan**
+- _Assemble the first edition of the shredder and begin integrated testing. (draft — verify)_
+
+**Bao Nguyen**
+- _Support shredder assembly and panel integration. (draft — verify)_
+
+**Fearghus Tyler**
+- Help assemble the first edition of the shredder.
+
+**Yaqoub Rabiah**
+- _Validate control logic on the assembled shredder. (draft — verify)_
+
+**Fox Kang**
+- _Validate the cap-touch trip on the assembled system. (draft — verify)_
+
+### Blocked
+
+**Bao Nguyen**
+- _None this week. (draft — verify)_
+
+**Fearghus Tyler**
+- _None this week. (draft — verify)_
+
+**Yaqoub Rabiah**
+- _None this week. (draft — verify)_
+
+**Fox Kang**
+- _None this week. (draft — verify)_
+
+---
+
+## Week 9 — Report date: 2026-05-30
+
+### Last week (hours)
+
+**Team Review**
+- _Assembled the first edition of the shredder with the mechanical team and began integrated commissioning. (draft — verify)_
+
+**Bao Nguyen**
+- _Supported shredder assembly; verified panel wiring and E-stop/deadman behavior on the integrated system. (16 hours) (draft — verify)_
+
+**Fearghus Tyler**
+- _Continued final documentation and user manual; supported assembly and any last DWG updates. (8 hours) (draft — verify)_
+
+**Yaqoub Rabiah**
+- _Tested control logic on the assembled shredder; tuned start/stop, forward/reverse, and overcurrent-clear behavior. (8 hours) (draft — verify)_
+
+**Fox Kang**
+- _Validated the capacitive-touch stop on the integrated system. (6 hours) (draft — verify)_
+
+### Next week
+
+**Team Plan**
+- _Final testing, finish the final report, and prepare for the end-of-term demo/expo. (draft — verify)_
+
+**Bao Nguyen**
+- _Finalize wiring documentation and contribute EE sections to the final report. (draft — verify)_
+
+**Fearghus Tyler**
+- _Finish user manual and export final schematics/DWGs for the report appendix. (draft — verify)_
+
+**Yaqoub Rabiah**
+- _Finalize PLC/HMI documentation and write up the control-logic section. (draft — verify)_
+
+**Fox Kang**
+- _Document the cap-touch module and write up its section. (draft — verify)_
+
+### Blocked
+
+**Bao Nguyen**
+- _None this week. (draft — verify)_
+
+**Fearghus Tyler**
+- _None this week. (draft — verify)_
+
+**Yaqoub Rabiah**
+- _None this week. (draft — verify)_
+
+**Fox Kang**
+- _None this week. (draft — verify)_
+
+---
+
+## Week 10 — Report date: 2026-06-06
+
+### Last week (hours)
+
+**Team Review**
+- _Completed final integrated testing, submitted the final report, and presented at the capstone demo/expo. (draft — verify)_
+
+**Bao Nguyen**
+- _Completed EE report sections (wiring, sizing, safety) and supported the final demo. (12 hours) (draft — verify)_
+
+**Fearghus Tyler**
+- _Finalized the user manual and design package; delivered final schematics and 3D enclosure model. (8 hours) (draft — verify)_
+
+**Yaqoub Rabiah**
+- _Finalized PLC/HMI control documentation and supported the demo. (8 hours) (draft — verify)_
+
+**Fox Kang**
+- _Finalized the capacitive-touch module documentation and demonstrated the touch-to-stop safety feature. (6 hours) (draft — verify)_
+
+### Next week
+
+**Team Plan**
+- _Term complete — project handed off to the sponsor. (draft — verify)_
+
+**Bao Nguyen**
+- _N/A — end of term. (draft — verify)_
+
+**Fearghus Tyler**
+- _N/A — end of term. (draft — verify)_
+
+**Yaqoub Rabiah**
+- _N/A — end of term. (draft — verify)_
+
+**Fox Kang**
+- _N/A — end of term. (draft — verify)_
+
+### Blocked
+
+**Bao Nguyen**
+- _None. (draft — verify)_
+
+**Fearghus Tyler**
+- _None. (draft — verify)_
+
+**Yaqoub Rabiah**
+- _None. (draft — verify)_
+
+**Fox Kang**
+- _None. (draft — verify)_


### PR DESCRIPTION
Adds `docs/weekly_progress_reports.md` compiling the team's weekly progress reports for the full year (2025-12-17 → 2026-06-06).

- Winter term (12 reports) and Spring term (Weeks 1–10).
- All originally-provided text kept verbatim.
- Blank sections (notably Fox Kang's entries and Weeks 8–10) and missing hours were drafted/estimated and tagged `(draft — verify)` — **verify before submitting.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)